### PR TITLE
Fix for automatic lgtm submit button css class property

### DIFF
--- a/src/lgtm.js
+++ b/src/lgtm.js
@@ -13,7 +13,7 @@ chrome.runtime.onMessage.addListener(
             console.log('LGTMed! ', message.data['imageUrl']);
             var submitButtonWrap = document.getElementById("partial-new-comment-form-actions");
             if (submitButtonWrap) {
-              var submitButtonCandidates = submitButtonWrap.getElementsByClassName("primary");
+              var submitButtonCandidates = submitButtonWrap.getElementsByClassName("btn-primary");
               if (submitButtonCandidates.length > 0) submitButtonCandidates[0].click()
             }
           }


### PR DESCRIPTION
Looks like github changed their css class for submit button.

Testing in Google Chrome console:

before
```javascript
> var submitButtonWrap = document.getElementById("partial-new-comment-form-actions");
<- undefined
> submitButtonWrap.getElementsByClassName("primary");
<- []
```

after
```javascript
> var submitButtonWrap = document.getElementById("partial-new-comment-form-actions");
<- undefined
> submitButtonWrap.getElementsByClassName("btn-primary");
<- [<button type="submit" class="btn btn-primary" tabindex="2" data-disable-with data-disable-invalid>
    Comment
  </button>]
```